### PR TITLE
Scrap rebalance & roof slopes

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -1,11 +1,15 @@
 local steel_item = "default:steel_ingot"
+local steel_block = "default:steelblock"
 
 if minetest.get_modpath("mcl_core") then
 	steel_item = "mcl_core:iron_ingot"
+	steel_block = "mcl_core:iron_block"
 elseif minetest.get_modpath("fl_ores") then
 	steel_item = "fl_ores:iron_ingot"
+	steel_block = "fl_ores:iron_block"
 end
 
+-- intra-mod recipes
 minetest.register_craft({
 	type = "cooking",
 	output = "steel:plate_hard",
@@ -18,9 +22,15 @@ minetest.register_craft({
 	recipe = "steel:grate_soft",
 })
 
+-- intra-mod recyling
 minetest.register_craft({
 	output = "steel:scrap 2",
 	recipe = {{"steel:strut"}}
+})
+
+minetest.register_craft({
+	output = "steel:scrap 2",
+	recipe = {{"steel:strut_mount"}}
 })
 
 minetest.register_craft({
@@ -48,6 +58,13 @@ minetest.register_craft({
 	recipe = {{"steel:plate_hard"}}
 })
 
+minetest.register_craft({
+	output = "steel:scrap 3",
+	recipe = {{"steel:plate_rusted"}}
+})
+
+
+-- extra-mod compatability
 if minetest.get_modpath("default") then
 	minetest.register_craft({
 		output = "steel:plate_soft 2",
@@ -86,6 +103,19 @@ if minetest.get_modpath("default") then
 	})
 end
 
+if minetest.get_modpath("technic") then
+	-- balance scrap racycling due to dust duplication
+	minetest.clear_craft({recipe={{"steel:scrap","steel:scrap"}}})
+	technic.register_grinder_recipe({input = {"steel:scrap 2"}, output="technic:wrought_iron_dust"})
+	
+	--use a semi-realistic crafting method
+	minetest.clear_craft({output="steel:roofing"})
+	technic.register_compressor_recipe({input = {steel_item.." 6"}, output = "steel:roofing"})
+	
+	minetest.clear_craft({output="steel:plate_soft"})
+	technic.register_compressor_recipe({input = {steel_block}, output = "steel:plate_soft"})
+end
+
 if not minetest.get_modpath("streets") or not minetest.get_modpath("steelsupport") then
 	minetest.register_craft({
 		output = "steel:strut 5",
@@ -95,4 +125,25 @@ if not minetest.get_modpath("streets") or not minetest.get_modpath("steelsupport
 			{"", steel_item, ""},
 		}
 	})
+end
+
+if minetest.get_modpath("moreblocks") then
+	stairsplus:register_panel("steel","roofing","steel:roofing", {
+		description = "Corrugated Steel Roofing",
+		tiles = {"steel_corrugated_steel.png"},
+		groups = {bendy = 2, snappy = 1, dig_immediate = 2, dig_generic = 1},
+		}
+	)
+	stairsplus:register_slab("steel","roofing","steel:roofing", {
+		description = "Corrugated Steel Roofing",
+		tiles = {"steel_corrugated_steel.png"},
+		groups = {bendy = 2, snappy = 1, dig_immediate = 2, dig_generic = 1},
+		}
+	)
+	stairsplus:register_slope("steel","roofing","steel:roofing", {
+		description = "Corrugated Steel Roofing",
+		tiles = {"steel_corrugated_steel.png"},
+		groups = {bendy = 2, snappy = 1, dig_immediate = 2, dig_generic = 1},
+		}
+	)
 end

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = steel
 description = Adds a range of steel materials that are recyclable.
-optional_depends = default, streets, unifieddyes, homedecor_roofing, fl_stone, fl_trees, mcl_sounds
+optional_depends = default, streets, unifieddyes, homedecor_roofing, fl_stone, fl_trees, mcl_sounds, moreblocks, technic


### PR DESCRIPTION
Noticed a lack of configurability provided by the raillike roofing nodes, so added moreblocks slopes and panels to provide roof peaks, valleys and walls.
Happened to notice recipe conflicts at the same time with items from MTG, so added technic compatibility to fix too.
Technic ore processing happened to introduce an infinite iron exploit, so scrap return had to be reduced to compensate.